### PR TITLE
fix: Holistic server auth token fix — pwd field name and refresh token flow

### DIFF
--- a/services/__tests__/serverAuth.test.ts
+++ b/services/__tests__/serverAuth.test.ts
@@ -214,6 +214,12 @@ describe('serverAuth', () => {
 
       await expect(serverAuth.refreshToken()).rejects.toThrow('Refresh token expired');
     });
+
+    it('throws descriptive error when no refresh token is stored in SecureStore', async () => {
+      (SecureStore.getItemAsync as jest.Mock).mockResolvedValueOnce(null);
+
+      await expect(serverAuth.refreshToken()).rejects.toThrow('No refresh token available. Please sign in again.');
+    });
   });
 
   describe('hasValidCredentials', () => {

--- a/services/serverAuth.ts
+++ b/services/serverAuth.ts
@@ -184,6 +184,14 @@ export const serverAuth = {
   async refreshToken(): Promise<string> {
     try {
       const storedRefreshToken = await SecureStore.getItemAsync(SERVER_REFRESH_TOKEN_KEY);
+
+      if (!storedRefreshToken) {
+        logger.error(
+          'Token refresh failed: no refresh token found in SecureStore. User may need to re-authenticate.'
+        );
+        throw new Error('No refresh token available. Please sign in again.');
+      }
+
       const response = await axiosPrivate.post('/refresh', { refreshToken: storedRefreshToken });
       const { accessToken, _id, refreshToken } = response.data;
 


### PR DESCRIPTION
## What
Fix dual root causes of 401 auth failures after user switch: wrong payload field name (`pwd` vs `password`) and cookie-based token refresh that React Native cannot support.

## Why
Closes #69. Users experienced cascading 401 errors after switching accounts because:
1. `loginToServer` and `registerOnServer` sent `pwd` but backend expects `password` — tokens were never stored
2. `refreshToken()` relied on httpOnly cookies, which React Native's native HTTP stack does not persist — refresh always failed with 401

## How
- `loginToServer` / `registerOnServer`: `pwd` → `password` to match `authController.js` and `registerController.js` contracts
- Add `SERVER_REFRESH_TOKEN_KEY = 'server_refresh_token'` constant
- `loginToServer`: store `refreshToken` from response in SecureStore when present
- `refreshToken()`: read stored refresh token from SecureStore, send in request body (`{ refreshToken }`) instead of relying on cookies
- `refreshToken()`: store new refresh token returned in response
- `logout()`: delete all three SecureStore keys (access token, user ID, refresh token)

**Backend dependency**: `millennials_prime#18` must deploy for end-to-end token refresh to work. The `/auth` endpoint must return `refreshToken` in the body, and `/refresh` must accept it from `req.body` instead of cookies only.

## Testing
- 25/25 unit tests pass (9 were failing RED before implementation)
- 1155/1155 total tests pass