### PR TITLE
fix: suppress index.tsx flash after splash screen on cold launch

### DIFF
--- a/app/__tests__/RootLayoutNav.test.tsx
+++ b/app/__tests__/RootLayoutNav.test.tsx
@@ -1,0 +1,135 @@
+import React from "react";
+import { ActivityIndicator } from "react-native";
+import { render, screen, act } from "@testing-library/react-native";
+import { RootLayoutNav } from "../_layout";
+import useAuth from "@/hooks/useAuth";
+import { useSegments, useRouter } from "expo-router";
+
+jest.mock("@/hooks/useAuth");
+
+jest.mock("expo-router", () => {
+  const ReactMock = require("react");
+  return {
+    useSegments: jest.fn(),
+    useRouter: jest.fn(),
+    Stack: Object.assign(
+      ({ children }: { children: React.ReactNode }) =>
+        ReactMock.createElement(ReactMock.Fragment, null, children),
+      { Screen: () => null }
+    ),
+  };
+});
+
+const mockUseAuth = useAuth as jest.Mock;
+const mockUseSegments = useSegments as jest.Mock;
+const mockUseRouter = useRouter as jest.Mock;
+
+describe("RootLayoutNav", () => {
+  const mockReplace = jest.fn();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockUseRouter.mockReturnValue({ replace: mockReplace });
+  });
+
+  describe("loading state", () => {
+    it("renders ActivityIndicator while auth is loading", () => {
+      mockUseAuth.mockReturnValue({ user: null, loading: true });
+      mockUseSegments.mockReturnValue([]);
+
+      render(<RootLayoutNav />);
+
+      expect(screen.UNSAFE_getByType(ActivityIndicator)).toBeTruthy();
+    });
+  });
+
+  describe("initial route — segments empty", () => {
+    it("renders ActivityIndicator when not loading but no route is active yet", () => {
+      mockUseAuth.mockReturnValue({ user: null, loading: false });
+      mockUseSegments.mockReturnValue([]);
+
+      render(<RootLayoutNav />);
+
+      expect(screen.UNSAFE_getByType(ActivityIndicator)).toBeTruthy();
+    });
+
+    it("renders ActivityIndicator for authenticated user when no route is active yet", () => {
+      mockUseAuth.mockReturnValue({ user: { uid: "123" }, loading: false });
+      mockUseSegments.mockReturnValue([]);
+
+      render(<RootLayoutNav />);
+
+      expect(screen.UNSAFE_getByType(ActivityIndicator)).toBeTruthy();
+    });
+
+    it("redirects unauthenticated user to sign-in", async () => {
+      mockUseAuth.mockReturnValue({ user: null, loading: false });
+      mockUseSegments.mockReturnValue([]);
+
+      render(<RootLayoutNav />);
+
+      await act(async () => {});
+
+      expect(mockReplace).toHaveBeenCalledWith("/(auth)/SignInScreen");
+    });
+
+    it("redirects authenticated user to home", async () => {
+      mockUseAuth.mockReturnValue({ user: { uid: "123" }, loading: false });
+      mockUseSegments.mockReturnValue([]);
+
+      render(<RootLayoutNav />);
+
+      await act(async () => {});
+
+      expect(mockReplace).toHaveBeenCalledWith("/(tabs)/(home)/HomePage");
+    });
+  });
+
+  describe("auth group routing", () => {
+    it("redirects authenticated user away from auth group to home", async () => {
+      mockUseAuth.mockReturnValue({ user: { uid: "123" }, loading: false });
+      mockUseSegments.mockReturnValue(["(auth)"]);
+
+      render(<RootLayoutNav />);
+
+      await act(async () => {});
+
+      expect(mockReplace).toHaveBeenCalledWith("/(tabs)/(home)/HomePage");
+    });
+
+    it("does not redirect unauthenticated user already on auth screen", async () => {
+      mockUseAuth.mockReturnValue({ user: null, loading: false });
+      mockUseSegments.mockReturnValue(["(auth)"]);
+
+      render(<RootLayoutNav />);
+
+      await act(async () => {});
+
+      expect(mockReplace).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("protected route routing", () => {
+    it("redirects unauthenticated user away from protected route to sign-in", async () => {
+      mockUseAuth.mockReturnValue({ user: null, loading: false });
+      mockUseSegments.mockReturnValue(["(tabs)"]);
+
+      render(<RootLayoutNav />);
+
+      await act(async () => {});
+
+      expect(mockReplace).toHaveBeenCalledWith("/(auth)/SignInScreen");
+    });
+
+    it("does not redirect authenticated user on a protected route", async () => {
+      mockUseAuth.mockReturnValue({ user: { uid: "123" }, loading: false });
+      mockUseSegments.mockReturnValue(["(tabs)"]);
+
+      render(<RootLayoutNav />);
+
+      await act(async () => {});
+
+      expect(mockReplace).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -7,6 +7,7 @@ import { BottomSheetModalProvider } from "@gorhom/bottom-sheet";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { AuthProvider } from "@/provider/AuthProvider";
 import useAuth from "@/hooks/useAuth";
+import { FirebaseAuthTypes } from "@react-native-firebase/auth";
 import { View, ActivityIndicator, LogBox } from "react-native";
 import ErrorBoundary from "@/components/ErrorBoundary";
 
@@ -31,30 +32,35 @@ const queryClient = new QueryClient({
 // Prevent the splash screen from auto-hiding before asset loading is complete.
 SplashScreen.preventAutoHideAsync();
 
-function RootLayoutNav() {
+function getRedirectTarget(
+  user: FirebaseAuthTypes.User | null,
+  segments: string[]
+): "/(tabs)/(home)/HomePage" | "/(auth)/SignInScreen" | null {
+  if (segments[0] === undefined) {
+    return user ? "/(tabs)/(home)/HomePage" : "/(auth)/SignInScreen";
+  }
+  if (user && segments[0] === "(auth)") {
+    return "/(tabs)/(home)/HomePage";
+  }
+  if (!user && segments[0] !== "(auth)") {
+    return "/(auth)/SignInScreen";
+  }
+  return null;
+}
+
+export function RootLayoutNav() {
   const { user, loading } = useAuth();
   const router = useRouter();
   const segments = useSegments();
 
   useEffect(() => {
     if (loading) return;
-
-    const inAuthGroup = segments[0] === "(auth)";
-
-    if (user && inAuthGroup) {
-      // User is signed in but on auth screens, redirect to home
-      router.replace("/(tabs)/(home)/HomePage");
-    } else if (!user && !inAuthGroup && segments[0] !== undefined) {
-      // User is not signed in but trying to access protected routes, redirect to sign in
-      router.replace("/(auth)/SignInScreen");
-    } else if (segments[0] === undefined) {
-      // No route set, redirect based on auth state
-      router.replace(user ? "/(tabs)/(home)/HomePage" : "/(auth)/SignInScreen");
-    }
+    const target = getRedirectTarget(user, segments as string[]);
+    if (target) router.replace(target);
   }, [user, loading, segments, router]);
 
-  if (loading) {
-    // Show loading indicator while checking auth state
+  if (loading || segments[0] === undefined) {
+    // Show loading indicator while checking auth state or waiting for initial route redirect
     return (
       <View style={{ flex: 1, justifyContent: "center", alignItems: "center" }}>
         <ActivityIndicator size="large" />


### PR DESCRIPTION
## What
Prevent the landing screen (`app/index.tsx`) from flashing during cold launch before navigation to sign-in or home.

## Why
Closes #82. On cold launch, `RootLayoutNav` rendered `index.tsx` for one frame while auth resolved, then the `useEffect` redirect fired — creating a jarring flash of the full landing screen.

## How
Extend the loading guard to also return the `ActivityIndicator` when `segments[0] === undefined` (the redirect is pending but hasn't fired yet). Extract redirect logic from the `useEffect` into `getRedirectTarget` pure function to remove the inline `inAuthGroup` variable and branch comments.

## Testing
- New `app/__tests__/RootLayoutNav.test.tsx` (9 tests) — covers spinner during loading, spinner when segments empty, all redirect scenarios
- Full suite: 65 test suites, 1192 tests passing